### PR TITLE
Fixed seo response in posts.

### DIFF
--- a/wp-graphql-seopress.php
+++ b/wp-graphql-seopress.php
@@ -73,10 +73,10 @@ add_action(
 									'metaRobotsNofollow'   => trim( get_post_meta( $post->ID, '_seopress_robots_follow', true ) ),
 									'opengraphTitle'       => trim( get_post_meta( $post->ID, '_seopress_social_fb_title', true ) ),
 									'opengraphDescription' => trim( get_post_meta( $post->ID, '_seopress_social_fb_desc', true ) ),
-									'opengraphImage'       => DataSource::resolve_post_object( get_post_meta( $post->ID, '_seopress_social_fb_img', true ), $context ),
+									'opengraphImage'       => trim( get_post_meta( $post->ID, '_seopress_social_fb_img', true ), $context),
 									'twitterTitle'         => trim( get_post_meta( $post->ID, '_seopress_social_twitter_title', true ) ),
 									'twitterDescription'   => trim( get_post_meta( $post->ID, '_seopress_social_twitter_desc', true ) ),
-									'twitterImage'         => DataSource::resolve_post_object( get_post_meta( $post->ID, '_seopress_social_twitter_img', true ), $context ),
+									'twitterImage'         => trim( get_post_meta( $post->ID, '_seopress_social_twitter_img', true ), $context),
 								);
 
 								return ! empty( $seo ) ? $seo : null;


### PR DESCRIPTION
Removed deprecated `DataSource::resolve_post_object`, and replaced it with `trim`

Potential #9 fix.

Tested on:
- Wordpress 5.7.2
- SEOPress 4.7.2

Tested on another dev site with SEOPress PRO 4.7.0