### PR TITLE
Only Run PHPCS on `master`

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,4 +1,7 @@
-on: pull_request
+on: 
+  pull_request:
+    branches:
+      - "master"
 
 name: Inspections
 jobs:


### PR DESCRIPTION
This is a workaround for PHPCS code reviewing to only work on PRs from same fork. Will start using `dev` branch for staging, and PR to `master` when release time.